### PR TITLE
Refactor UDPServer: State Pattern and Class Separation

### DIFF
--- a/src/UDPClient.java
+++ b/src/UDPClient.java
@@ -1,4 +1,4 @@
-import game.GameState;
+import game.GameStateEnum;
 import message.Message;
 import message.MessageFabric;
 import player.PlayerSide;
@@ -15,21 +15,21 @@ public class UDPClient {
         Connection connection = new Connection(socket, InetAddress.getByName(Config.SERVER_ADDRESS), Config.SERVER_PORT);
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
 
-        GameState gameState = GameState.PLAYER_CONNECTING_SERVER;
+        GameStateEnum gameStateEnum = GameStateEnum.PLAYER_CONNECTING_SERVER;
 
         int counter = 0;
         Message msg = null;
 
-        gameLoop: while (gameState != GameState.ENDED) {
-            switch (gameState) {
-                case GameState.PLAYER_CONNECTING_SERVER:
+        gameLoop: while (gameStateEnum != GameStateEnum.ENDED) {
+            switch (gameStateEnum) {
+                case GameStateEnum.PLAYER_CONNECTING_SERVER:
                     connection.sendMessage(MessageFabric.createConnectionMessage());
                     msg = connection.readMessage(2000);
 
                     System.out.println(msg);
 
                     if(msg != null && !msg.isErrorMessage()) {
-                        gameState = GameState.PLAYER_WAITING_OTHERS;
+                        gameStateEnum = GameStateEnum.PLAYER_WAITING_OTHERS;
                     } else {
                         System.out.println("O servidor já está lotado");
                         System.out.println("Desconectando...");
@@ -42,8 +42,8 @@ public class UDPClient {
                 case PLAYER_WAITING_OTHERS:
                     msg = connection.readMessage();
 
-                    if (msg != null && msg.isGameStateMessage() && msg.getFields()[1] == GameState.WAITING_PLAYERS_CHOOSE_SIDE.ordinal()) {
-                        gameState = GameState.PLAYER_CHOOSING_SIDE;
+                    if (msg != null && msg.isGameStateMessage() && msg.getFields()[1] == GameStateEnum.WAITING_PLAYERS_CHOOSE_SIDE.ordinal()) {
+                        gameStateEnum = GameStateEnum.PLAYER_CHOOSING_SIDE;
                         System.out.println("Jogadores conectados");
                     } else if (counter <= 0) {
                         System.out.println("Esperando jogadores se conectarem...");
@@ -65,7 +65,7 @@ public class UDPClient {
                             System.out.println("Esse lado já foi escolhido por outro jogador!");
                             continue;
                         } else {
-                            gameState = GameState.PLAYER_WAITING_OPPONENT_CHOOSE;
+                            gameStateEnum = GameStateEnum.PLAYER_WAITING_OPPONENT_CHOOSE;
                         }
                     }
 
@@ -76,8 +76,8 @@ public class UDPClient {
                     while(true) {
                         msg = connection.readMessage(2000);
 
-                        if(msg != null && msg.getFields()[1] == GameState.WAITING_PLAYERS_CHOOSE_PLAY.ordinal()) {
-                            gameState = GameState.PLAYER_CHOOSING_PLAY;
+                        if(msg != null && msg.getFields()[1] == GameStateEnum.WAITING_PLAYERS_CHOOSE_PLAY.ordinal()) {
+                            gameStateEnum = GameStateEnum.PLAYER_CHOOSING_PLAY;
                             break;
                         } else {
                             Thread.sleep(500);
@@ -93,7 +93,7 @@ public class UDPClient {
                     msg = connection.readMessage(2000);
 
                     if(msg != null) {
-                        gameState = GameState.PLAYER_WAITING_RESULT;
+                        gameStateEnum = GameStateEnum.PLAYER_WAITING_RESULT;
                     }
 
                     break;
@@ -103,7 +103,7 @@ public class UDPClient {
                     if(msg != null && msg.isEndGameMessage()) {
                         String endGameMessage = msg.getFields()[1] != 0 ? "Você ganhou :)" : "Você perdeu :(";
                         System.out.println(endGameMessage);
-                        gameState = GameState.PLAYER_RESTART_OR_END;
+                        gameStateEnum = GameStateEnum.PLAYER_RESTART_OR_END;
                     }
 
                     break;

--- a/src/UDPServer.java
+++ b/src/UDPServer.java
@@ -1,18 +1,8 @@
-import game.GameState;
 import game.OddEven;
-import game.exceptions.GameFullException;
-import game.exceptions.SideAlreadyChosenException;
-import message.Message;
-import message.MessageFabric;
-import player.Player;
-import player.PlayerSide;
+import game.network.Broadcaster;
+import game.network.Receiver;
 
-import java.io.*;
-import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
 
 public class UDPServer {
     public static void main(String[] args) throws Exception {
@@ -22,208 +12,15 @@ public class UDPServer {
         System.out.println("Server UDP rodando na porta: " + Config.SERVER_PORT);
 
         OddEven oddEven = new OddEven();
-        ClientPacket packet = null;
-
-        GameState lastLoggedGameState = null;
 
         while (!oddEven.isOver()) {
-            if(lastLoggedGameState != oddEven.getState()){
-                logGameState(oddEven.getState());
-                lastLoggedGameState = oddEven.getState();
-            }
-
             try {
-                switch (oddEven.getState()) {
-                    case GameState.WAITING_PLAYERS:
-                        packet = serverReceiver.readMessage();
-                        if(packet == null) break;
-
-                        try {
-                            oddEven.addPlayer(new Player(packet.address(), packet.port()));
-                            System.out.println("Novo jogador com IP: " + packet.address() + " e porta: " + packet.port());
-                            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createOkMessage()));
-
-                            if (oddEven.isFull()) {
-                                oddEven.setState(GameState.WAITING_PLAYERS_CHOOSE_SIDE);
-
-                                for (Player player : oddEven.getPlayers().values()) {
-                                    Message msgState = MessageFabric.createGameStateMessage(GameState.WAITING_PLAYERS_CHOOSE_SIDE);
-                                    serverBroadcaster.sendMessage(new ClientPacket(player.getAddress(), player.getPort(), msgState));
-                                }
-                            }
-                        } catch (GameFullException e) {
-                            Message errorMsg = MessageFabric.createErrorMessage();
-                            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), errorMsg));
-                        }
-
-                        break;
-                    case WAITING_PLAYERS_CHOOSE_SIDE:
-                        packet = serverReceiver.readMessage();
-
-                        if(packet == null || !packet.message.isChooseSideMessage()) break;
-
-                        PlayerSide chosenSide = PlayerSide.values()[packet.message().getFields()[1]];
-                        System.out.println("Escolha de lado recebida do IP: " + packet.address() + " e porta: " + packet.port() + " valor: " + chosenSide);
-
-                        String playerKey = packet.address().toString() + packet.port();
-
-                        try {
-                            oddEven.chooseSide(playerKey, chosenSide);
-                            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createOkMessage()));
-
-                            if (oddEven.hasAllPlayersChosenSide()) {
-                                oddEven.setState(GameState.WAITING_PLAYERS_CHOOSE_PLAY);
-
-                                for (Player player : oddEven.getPlayers().values()) {
-                                    Message msgState = MessageFabric.createGameStateMessage(GameState.WAITING_PLAYERS_CHOOSE_PLAY);
-                                    serverBroadcaster.sendMessage(new ClientPacket(player.getAddress(), player.getPort(), msgState));
-                                }
-                            }
-
-                        } catch (SideAlreadyChosenException e) {
-                            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createErrorMessage()));
-                        }
-                        break;
-                    case WAITING_PLAYERS_CHOOSE_PLAY:
-                        packet = serverReceiver.readMessage();
-                        if(packet == null) break;
-
-                        if (packet.message().isPlayMessage()) {
-                            int playerPlay = packet.message().getFields()[1];
-                            oddEven.play(playerPlay);
-                            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createOkMessage()));
-                        }
-
-                        if (oddEven.hasAllPlayersPlayed()) oddEven.setState(GameState.COMPUTE_RESULT);
-
-                        System.out.println(oddEven.hasAllPlayersPlayed());
-
-                        break;
-
-                    case COMPUTE_RESULT:
-                        Player winnerPlayer = oddEven.computeWinner();
-
-                        if (winnerPlayer != null) {
-                            for (Player player : oddEven.getPlayers().values()) {
-                                serverBroadcaster.sendMessage(new ClientPacket(player.getAddress(), player.getPort(), MessageFabric.createEndGameMessage(player.equals(winnerPlayer))));
-                            }
-                        }
-
-                        break;
-                    case WAITING_PLAYERS_RESTART_OR_END:
-                        break;
-                }
+                oddEven.processRequest(serverReceiver, serverBroadcaster);
             } catch (Exception e) {
                 e.printStackTrace();
             }
 
             Thread.sleep(1000);
         }
-    }
-
-    public static void logGameState(GameState state) {
-        switch(state) {
-            case WAITING_PLAYERS:
-                System.out.println("Esperando jogadores se conectarem...");
-                break;
-            case WAITING_PLAYERS_CHOOSE_SIDE:
-                System.out.println("Esperando jogadores escolherem seus lados...");
-                break;
-            case WAITING_PLAYERS_CHOOSE_PLAY:
-                System.out.println("Esperando jogadores escolherem suas jogadas...");
-                break;
-            case COMPUTE_RESULT:
-                System.out.println("Calculando resultado do jogo...");
-            case WAITING_PLAYERS_RESTART_OR_END:
-                System.out.println("Aguardando jogadores decidirem se desejam jogar ou finalizar o jogo");
-            default:
-        }
-    }
-
-    private static class Broadcaster extends Thread {
-        private final DatagramSocket socket;
-        private final Queue<ClientPacket> queue;
-
-        public Broadcaster(DatagramSocket socket) {
-            this.socket = socket;
-            this.queue = new ArrayBlockingQueue<>(10);
-            this.start();
-        }
-
-        public void sendMessage(ClientPacket packet) {
-            this.queue.offer(packet);
-        }
-
-        @Override
-        public void run() {
-            while (true) {
-                if (!queue.isEmpty()) {
-                    try {
-                        ClientPacket clientPacket = queue.remove();
-
-                        InetAddress destinationIp = clientPacket.address();
-                        int destinationPort = clientPacket.port();
-
-                        ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
-                        ObjectOutputStream objectOutStream = new ObjectOutputStream(byteOutStream);
-                        objectOutStream.writeObject(clientPacket.message());
-                        byte[] objectData = byteOutStream.toByteArray();
-
-                        DatagramPacket packet = new DatagramPacket(objectData, objectData.length, destinationIp, destinationPort);
-
-                        System.out.println("Enviando mensagem para o IP: " + destinationIp + " e porta: " + destinationPort);
-
-                        this.socket.send(packet);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                } else {
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-    }
-
-    public static class Receiver extends Thread {
-        private final DatagramSocket socket;
-        private final Queue<ClientPacket> queue;
-
-        public Receiver(DatagramSocket socket) {
-            this.socket = socket;
-            this.queue = new ArrayBlockingQueue<>(10);
-
-            this.start();
-        }
-
-        public synchronized ClientPacket readMessage() {
-            return this.queue.poll();
-        }
-
-        @Override
-        public void run() {
-            try {
-                while (true) {
-                    byte[] buffer = new byte[1024];
-
-                    DatagramPacket receivePacket = new DatagramPacket(buffer, buffer.length);
-                    this.socket.receive(receivePacket);
-
-                    ByteArrayInputStream byteInStream = new ByteArrayInputStream(buffer);
-                    ObjectInputStream objectInStream = new ObjectInputStream(byteInStream);
-                    Message msg = (Message) objectInStream.readObject();
-
-                    this.queue.offer(new ClientPacket(receivePacket.getAddress(), receivePacket.getPort(), msg));
-                }
-            } catch (IOException | ClassNotFoundException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    public record ClientPacket(InetAddress address, int port, Message message) {
     }
 }

--- a/src/game/GameStateEnum.java
+++ b/src/game/GameStateEnum.java
@@ -1,6 +1,6 @@
 package game;
 
-public enum GameState {
+public enum GameStateEnum {
     //Server
     WAITING_PLAYERS,
     WAITING_PLAYERS_CHOOSE_SIDE,

--- a/src/game/OddEven.java
+++ b/src/game/OddEven.java
@@ -2,6 +2,10 @@ package game;
 
 import game.exceptions.GameFullException;
 import game.exceptions.SideAlreadyChosenException;
+import game.network.Broadcaster;
+import game.network.Receiver;
+import game.states.State;
+import game.states.WaitingPlayers;
 import player.Player;
 import player.PlayerSide;
 
@@ -12,11 +16,21 @@ import java.util.HashMap;
 public class OddEven {
     HashMap<String, Player> players = new HashMap<>();
     private boolean isOver = false;
-    private GameState state = GameState.WAITING_PLAYERS;
     private ArrayList<Integer> availableSides = new ArrayList<>(Arrays.asList(PlayerSide.ODD.ordinal(), PlayerSide.EVEN.ordinal()));
     private ArrayList<Integer> playList = new ArrayList<>();
+    private State currentState;
 
-    public OddEven(){}
+    public OddEven(){
+        this.currentState = new WaitingPlayers(this);
+    }
+
+    public void changeState(State state) {
+        this.currentState = state;
+    }
+
+    public void processRequest(Receiver receiver, Broadcaster broadcaster) {
+        this.currentState.handle(receiver, broadcaster);
+    }
 
     public void addPlayer(Player player) throws GameFullException {
         if(isFull()) {
@@ -77,14 +91,6 @@ public class OddEven {
 
     public boolean hasAllPlayersPlayed(){
         return this.playList.size() == 2;
-    }
-
-    public GameState getState(){
-        return this.state;
-    }
-
-    public void setState(GameState state) {
-        this.state = state;
     }
 
     public HashMap<String, Player> getPlayers() {

--- a/src/game/network/Broadcaster.java
+++ b/src/game/network/Broadcaster.java
@@ -1,0 +1,60 @@
+package game.network;
+
+import game.utils.ClientPacket;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+public class Broadcaster extends Thread {
+    private final DatagramSocket socket;
+    private final Queue<ClientPacket> queue;
+
+    public Broadcaster(DatagramSocket socket) {
+        this.socket = socket;
+        this.queue = new ArrayBlockingQueue<>(10);
+        this.start();
+    }
+
+    public void sendMessage(ClientPacket packet) {
+        this.queue.offer(packet);
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+            if (!queue.isEmpty()) {
+                try {
+                    ClientPacket clientPacket = queue.remove();
+
+                    InetAddress destinationIp = clientPacket.address();
+                    int destinationPort = clientPacket.port();
+
+                    ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+                    ObjectOutputStream objectOutStream = new ObjectOutputStream(byteOutStream);
+                    objectOutStream.writeObject(clientPacket.message());
+                    byte[] objectData = byteOutStream.toByteArray();
+
+                    DatagramPacket packet = new DatagramPacket(objectData, objectData.length, destinationIp, destinationPort);
+
+                    System.out.println("Enviando mensagem para o IP: " + destinationIp + " e porta: " + destinationPort);
+
+                    this.socket.send(packet);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/src/game/network/Receiver.java
+++ b/src/game/network/Receiver.java
@@ -1,0 +1,48 @@
+package game.network;
+
+import game.utils.ClientPacket;
+import message.Message;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+public class Receiver extends Thread {
+    private final DatagramSocket socket;
+    private final Queue<ClientPacket> queue;
+
+    public Receiver(DatagramSocket socket) {
+        this.socket = socket;
+        this.queue = new ArrayBlockingQueue<>(10);
+
+        this.start();
+    }
+
+    public synchronized ClientPacket readMessage() {
+        return this.queue.poll();
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (true) {
+                byte[] buffer = new byte[1024];
+
+                DatagramPacket receivePacket = new DatagramPacket(buffer, buffer.length);
+                this.socket.receive(receivePacket);
+
+                ByteArrayInputStream byteInStream = new ByteArrayInputStream(buffer);
+                ObjectInputStream objectInStream = new ObjectInputStream(byteInStream);
+                Message msg = (Message) objectInStream.readObject();
+
+                this.queue.offer(new ClientPacket(receivePacket.getAddress(), receivePacket.getPort(), msg));
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/game/states/ComputeResult.java
+++ b/src/game/states/ComputeResult.java
@@ -1,0 +1,30 @@
+package game.states;
+
+import game.OddEven;
+import game.network.Broadcaster;
+import game.network.Receiver;
+import game.utils.ClientPacket;
+import message.MessageFabric;
+import player.Player;
+
+public class ComputeResult extends State {
+    String message = "Calculando o resultado da partida...";
+
+    public ComputeResult(OddEven game) {
+        super(game);
+        logStateMessage(message);
+    }
+
+    @Override
+    public void handle(Receiver receiver, Broadcaster broadcaster) {
+        Player winnerPlayer = game.computeWinner();
+
+        if (winnerPlayer != null) {
+            for (Player player : game.getPlayers().values()) {
+                broadcaster.sendMessage(new ClientPacket(player.getAddress(), player.getPort(), MessageFabric.createEndGameMessage(player.equals(winnerPlayer))));
+            }
+
+            game.changeState(new WaitingPlayersRestartOrEnd(game));
+        }
+    }
+}

--- a/src/game/states/State.java
+++ b/src/game/states/State.java
@@ -1,0 +1,19 @@
+package game.states;
+
+import game.OddEven;
+import game.network.Broadcaster;
+import game.network.Receiver;
+
+public abstract class State {
+    protected OddEven game;
+
+    public State(OddEven game){
+        this.game = game;
+    }
+
+    public abstract void handle(Receiver receiver, Broadcaster broadcaster);
+
+    public void logStateMessage(String message){
+        System.out.println(message);
+    }
+}

--- a/src/game/states/WaitingPlayers.java
+++ b/src/game/states/WaitingPlayers.java
@@ -1,0 +1,45 @@
+package game.states;
+
+import game.GameStateEnum;
+import game.OddEven;
+import game.exceptions.GameFullException;
+import game.network.Broadcaster;
+import game.network.Receiver;
+import game.utils.ClientPacket;
+import message.Message;
+import message.MessageFabric;
+import player.Player;
+
+public class WaitingPlayers extends State {
+    String message = "Aguardando jogadores se conectarem...";
+
+    public WaitingPlayers(OddEven game) {
+        super(game);
+        logStateMessage(message);
+    }
+
+    public void handle(Receiver serverReceiver, Broadcaster serverBroadcaster) {
+        ClientPacket packet = serverReceiver.readMessage();
+        if(packet == null) return;
+
+        try {
+            game.addPlayer(new Player(packet.address(), packet.port()));
+            System.out.println("Novo jogador com IP: " + packet.address() + " e porta: " + packet.port());
+            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createOkMessage()));
+
+            if (game.isFull()) {
+
+                game.changeState(new WaitingPlayersChooseSide(game));
+
+                for (Player player : game.getPlayers().values()) {
+                    Message msgState = MessageFabric.createGameStateMessage(GameStateEnum.WAITING_PLAYERS_CHOOSE_SIDE);
+                    serverBroadcaster.sendMessage(new ClientPacket(player.getAddress(), player.getPort(), msgState));
+                }
+            }
+        } catch (GameFullException e) {
+            Message errorMsg = MessageFabric.createErrorMessage();
+            serverBroadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), errorMsg));
+        }
+
+    }
+}

--- a/src/game/states/WaitingPlayersChoosePlay.java
+++ b/src/game/states/WaitingPlayersChoosePlay.java
@@ -1,0 +1,31 @@
+package game.states;
+
+import game.GameStateEnum;
+import game.OddEven;
+import game.network.Broadcaster;
+import game.network.Receiver;
+import game.utils.ClientPacket;
+import message.MessageFabric;
+
+public class WaitingPlayersChoosePlay extends State {
+    String message = "Aguardando jogadores escolherem suas jogadas...";
+
+    public WaitingPlayersChoosePlay(OddEven game) {
+        super(game);
+        logStateMessage(message);
+    }
+
+    @Override
+    public void handle(Receiver receiver, Broadcaster broadcaster) {
+        ClientPacket packet = receiver.readMessage();
+        if(packet == null) return;
+
+        if (packet.message().isPlayMessage()) {
+            int playerPlay = packet.message().getFields()[1];
+            game.play(playerPlay);
+            broadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createOkMessage()));
+        }
+
+        if (game.hasAllPlayersPlayed()) game.changeState(new ComputeResult(game));
+    }
+}

--- a/src/game/states/WaitingPlayersChooseSide.java
+++ b/src/game/states/WaitingPlayersChooseSide.java
@@ -1,0 +1,50 @@
+package game.states;
+
+import game.GameStateEnum;
+import game.OddEven;
+import game.exceptions.SideAlreadyChosenException;
+import game.network.Broadcaster;
+import game.network.Receiver;
+import game.utils.ClientPacket;
+import message.Message;
+import message.MessageFabric;
+import player.Player;
+import player.PlayerSide;
+
+public class WaitingPlayersChooseSide extends State {
+    String message = "Aguardando jogadores escolherem seus lados...";
+
+    public WaitingPlayersChooseSide(OddEven game) {
+        super(game);
+        logStateMessage(message);
+    }
+
+    @Override
+    public void handle(Receiver receiver, Broadcaster broadcaster) {
+        ClientPacket packet = receiver.readMessage();
+
+        if(packet == null || !packet.message().isChooseSideMessage()) return;
+
+        PlayerSide chosenSide = PlayerSide.values()[packet.message().getFields()[1]];
+        System.out.println("Escolha de lado recebida do IP: " + packet.address() + " e porta: " + packet.port() + " valor: " + chosenSide);
+
+        String playerKey = packet.address().toString() + packet.port();
+
+        try {
+            game.chooseSide(playerKey, chosenSide);
+            broadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createOkMessage()));
+
+            if (game.hasAllPlayersChosenSide()) {
+                game.changeState(new WaitingPlayersChoosePlay(game));
+
+                for (Player player : game.getPlayers().values()) {
+                    Message msgState = MessageFabric.createGameStateMessage(GameStateEnum.WAITING_PLAYERS_CHOOSE_PLAY);
+                    broadcaster.sendMessage(new ClientPacket(player.getAddress(), player.getPort(), msgState));
+                }
+            }
+
+        } catch (SideAlreadyChosenException e) {
+            broadcaster.sendMessage(new ClientPacket(packet.address(), packet.port(), MessageFabric.createErrorMessage()));
+        }
+    }
+}

--- a/src/game/states/WaitingPlayersRestartOrEnd.java
+++ b/src/game/states/WaitingPlayersRestartOrEnd.java
@@ -1,0 +1,22 @@
+package game.states;
+
+import game.OddEven;
+import game.network.Broadcaster;
+import game.network.Receiver;
+import game.utils.ClientPacket;
+import message.MessageFabric;
+
+public class WaitingPlayersRestartOrEnd extends State {
+    String message = "Aguardando jogadores decidirem se desejam continuar jogando ou encerrar o jogo";
+
+    public WaitingPlayersRestartOrEnd(OddEven game) {
+        super(game);
+        logStateMessage(message);
+    }
+
+    @Override
+    public void handle(Receiver receiver, Broadcaster broadcaster) {
+        ClientPacket packet = receiver.readMessage();
+        if(packet == null) return;
+    }
+}

--- a/src/game/utils/ClientPacket.java
+++ b/src/game/utils/ClientPacket.java
@@ -1,0 +1,7 @@
+package game.utils;
+
+import message.Message;
+
+import java.net.InetAddress;
+
+public record ClientPacket(InetAddress address, int port, Message message) {}

--- a/src/message/MessageFabric.java
+++ b/src/message/MessageFabric.java
@@ -1,6 +1,6 @@
 package message;
 
-import game.GameState;
+import game.GameStateEnum;
 import player.PlayerSide;
 
 public class MessageFabric {
@@ -21,7 +21,7 @@ public class MessageFabric {
         return msg;
     }
 
-    public static Message createGameStateMessage(GameState state) {
+    public static Message createGameStateMessage(GameStateEnum state) {
         Message msg = new Message(new int[Message.MSG_SIZE]);
 
         msg.getFields()[0] = MessageType.GAME_STATE.ordinal();


### PR DESCRIPTION
Esse PR implementa o padrão de projeto _State Pattern_ do lado do servidor para substituir a máquina de estados com `switch...case` e diminuir a sobrecarga de código no método `main`

Referência: [State Pattern](https://refactoring.guru/design-patterns/state)